### PR TITLE
refactor: manage calendar view with reducer

### DIFF
--- a/src/components/CalendarGrid.jsx
+++ b/src/components/CalendarGrid.jsx
@@ -1,11 +1,10 @@
 import React from "react";
-import MovieCard from "./MovieCard.jsx";
 import { MOVIES } from "../data/movies.js";
 
 export default function CalendarGrid({
   enriched,
   weeks,
-  handleSetSelectedDate,
+  dispatch,
 }) {
   return (
     <>
@@ -44,7 +43,10 @@ export default function CalendarGrid({
                   type="button"
                   onClick={() => {
                     if (inMonth && movie) {
-                      handleSetSelectedDate(iso, movie);
+                      dispatch({
+                        type: "SELECT_MOVIE",
+                        payload: { date: iso, movie },
+                      });
                     }
                   }}
                   className={[

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -6,7 +6,7 @@ import { FacebookShareButton } from "./ShareButtons.jsx";
 export default function MovieCard({
   movie,
   accent = false,
-  handleBackToCalendar,
+  dispatch,
 }) {
   function isiOS() {
     return /iP(hone|ad|od)/i.test(navigator.userAgent);
@@ -66,7 +66,10 @@ export default function MovieCard({
       } p-4`}
     >
       <div className="flex w-full justify-end">
-        <button className="appearance-none bg-zinc-900" onClick={handleBackToCalendar}>
+        <button
+          className="appearance-none bg-zinc-900"
+          onClick={() => dispatch({ type: "BACK_TO_CALENDAR" })}
+        >
           Back to calendar
         </button>
       </div>

--- a/src/state/calendarReducer.js
+++ b/src/state/calendarReducer.js
@@ -1,0 +1,24 @@
+export const initialState = {
+  selectedDate: null,
+  movie: null,
+  view: 'calendar',
+};
+
+export function calendarReducer(state, action) {
+  switch (action.type) {
+    case 'SELECT_MOVIE':
+      return {
+        ...state,
+        selectedDate: action.payload.date,
+        movie: action.payload.movie,
+        view: 'movie',
+      };
+    case 'BACK_TO_CALENDAR':
+      return {
+        ...state,
+        view: 'calendar',
+      };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize calendar state in calendarReducer
- dispatch SELECT_MOVIE and BACK_TO_CALENDAR from CalendarGrid and MovieCard
- switch App to useReducer for selected movie and view state

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c486b6db048325b173f7e63e37a25f