### PR TITLE
feat: persist modal visibility using local storage hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,21 +5,19 @@ import MovieCard from "./components/MovieCard.jsx";
 import CalendarGrid from "./components/CalendarGrid.jsx";
 import Footer from "./components/Footer.jsx";
 import Popup from "./components/Popup.jsx";
+import useLocalStorage from "./hooks/useLocalStorage.js";
 
 const EVENT_VIDEO_URL = "https://www.youtube.com/embed/D9OoGhS5ilE";
 
 export default function App() {
   const INTRO_KEY = "introDismissed_v1";
   const [enriched, setEnriched] = useState({});
-  const [modalOpen, setModalOpen] = useState(
-    localStorage.getItem(INTRO_KEY) ? false : true
-  );
+  const [modalOpen, setModalOpen] = useLocalStorage(INTRO_KEY, false);
 
   const { weeks } = useMemo(() => buildCalendar(2025, 9), []);
 
   const handleCloseForever = () => {
     setModalOpen(false);
-    localStorage.setItem(INTRO_KEY, "1");
   };
 
   const handleClose = () => {

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+export default function useLocalStorage(key, defaultValue) {
+  const [value, setValue] = useState(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? JSON.parse(stored) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}


### PR DESCRIPTION
## Summary
- add `useLocalStorage` hook to read/write values in `localStorage`
- persist modal visibility with the new hook
- remove direct `localStorage` mutations from `App`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c48edbe5408325beb81f490770ff47