### PR TITLE
refactor: use component-level button colors

### DIFF
--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -67,7 +67,7 @@ export default function MovieCard({
     >
       <div className="flex w-full justify-end">
         <button
-          className="appearance-none bg-zinc-900"
+          className="appearance-none rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-sm text-zinc-100 hover:bg-zinc-800"
           onClick={onBack}
         >
           Back to calendar
@@ -115,7 +115,7 @@ export default function MovieCard({
               }
               type="button"
               rel="noreferrer"
-              className="appearance-none inline-flex items-center rounded-lg px-3 py-1.5 text-sm text-emerald-300 hover:bg-emerald-800/30"
+              className="appearance-none inline-flex items-center rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-sm text-emerald-300 hover:bg-emerald-800/30"
             >
               Watch on Tubi
             </button>

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -47,14 +47,14 @@ export default function Popup({
               <button
                 ref={closeBtnRef}
                 onClick={handleClose}
-                className=" appearance-none ml-4 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm"
+                className="appearance-none ml-4 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 hover:bg-zinc-700"
                 aria-label="Close"
               >
                 Close
               </button>
               <button
                 onClick={handleCloseForever}
-                className="appearance-none ml-4 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm"
+                className="appearance-none ml-4 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 hover:bg-zinc-700"
                 aria-label="Close forever"
               >
                 Don't open again

--- a/src/components/ShareButtons.jsx
+++ b/src/components/ShareButtons.jsx
@@ -14,7 +14,7 @@ export function FacebookShareButton({ dateISO, title }) {
     <button
       type="button"
       onClick={() => window.open(fbShareUrl({ shareUrl, quote }), "_blank", "noopener,noreferrer")}
-      className="inline-flex items-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm hover:bg-zinc-700"
+      className="inline-flex items-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 hover:bg-zinc-700"
       title="Share on Facebook"
     >
       Share on Facebook

--- a/src/index.css
+++ b/src/index.css
@@ -35,25 +35,6 @@ h1 {
   line-height: 1.1;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -61,9 +42,6 @@ button:focus-visible {
   }
   a:hover {
     color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove global button styles from index.css
- style buttons directly with Tailwind color classes for consistent rendering

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4ddf225388325b413c59793463eca