### PR TITLE
Improve Facebook share behavior on mobile

### DIFF
--- a/src/components/ShareButtons.jsx
+++ b/src/components/ShareButtons.jsx
@@ -7,13 +7,47 @@ function fbShareUrl({ shareUrl, quote }) {
   return u.toString();
 }
 
+function facebookShareTargets(params) {
+  const webShareUrl = fbShareUrl(params);
+  const deepLinkUrl = `fb://facewebmodal/f?href=${encodeURIComponent(webShareUrl)}`;
+  return { webShareUrl, deepLinkUrl };
+}
+
 export function FacebookShareButton({ dateISO, title }) {
-  const shareUrl = `${window.location.origin}/share/${dateISO}.html`;
-  const quote = `I watched ${title} on ${dateISO}!`;
+  const shareParams = {
+    shareUrl: `${window.location.origin}/share/${dateISO}.html`,
+    quote: `I watched ${title} on ${dateISO}!`,
+  };
+  const { webShareUrl, deepLinkUrl } = facebookShareTargets(shareParams);
+
   return (
     <button
       type="button"
-      onClick={() => window.open(fbShareUrl({ shareUrl, quote }), "_blank", "noopener,noreferrer")}
+      onClick={() => {
+        const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+        if (isMobile) {
+          let fallbackTimeout;
+          const handleVisibilityChange = () => {
+            if (document.hidden && fallbackTimeout) {
+              clearTimeout(fallbackTimeout);
+              document.removeEventListener("visibilitychange", handleVisibilityChange);
+            }
+          };
+
+          document.addEventListener("visibilitychange", handleVisibilityChange);
+
+          fallbackTimeout = window.setTimeout(() => {
+            document.removeEventListener("visibilitychange", handleVisibilityChange);
+            window.location.href = webShareUrl;
+          }, 500);
+
+          window.location.href = deepLinkUrl;
+          return;
+        }
+
+        window.open(webShareUrl, "_blank", "noopener,noreferrer");
+      }}
       className="inline-flex items-center rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 hover:bg-zinc-700"
       title="Share on Facebook"
     >


### PR DESCRIPTION
## Summary
- build the Facebook web share URL and native deep link from a shared set of parameters
- add mobile user-agent detection that tries the native deep link before falling back to the web dialog

## Testing
- npm run lint *(warns about an unrelated existing exhaustive-deps warning)*

------
https://chatgpt.com/codex/tasks/task_e_68d07bf924008325aa65ba40efbeba85