### PR TITLE
Update Facebook share deep link

### DIFF
--- a/src/components/ShareButtons.jsx
+++ b/src/components/ShareButtons.jsx
@@ -1,15 +1,19 @@
 import React from "react";
 
-function fbShareUrl({ shareUrl, quote }) {
-  const u = new URL("https://www.facebook.com/sharer/sharer.php");
+const DESKTOP_SHARE_ENDPOINT = "https://www.facebook.com/sharer/sharer.php";
+const MOBILE_SHARE_ENDPOINT = "https://m.facebook.com/sharer.php";
+
+function buildFbShareUrl({ shareUrl, quote }, baseUrl) {
+  const u = new URL(baseUrl);
   u.searchParams.set("u", shareUrl);
   if (quote) u.searchParams.set("quote", quote);
   return u.toString();
 }
 
 function facebookShareTargets(params) {
-  const webShareUrl = fbShareUrl(params);
-  const deepLinkUrl = `fb://facewebmodal/f?href=${encodeURIComponent(webShareUrl)}`;
+  const webShareUrl = buildFbShareUrl(params, DESKTOP_SHARE_ENDPOINT);
+  const mobileShareUrl = buildFbShareUrl(params, MOBILE_SHARE_ENDPOINT);
+  const deepLinkUrl = `fb://facewebmodal/f?href=${encodeURIComponent(mobileShareUrl)}`;
   return { webShareUrl, deepLinkUrl };
 }
 


### PR DESCRIPTION
## Summary
- add dedicated desktop and mobile Facebook share endpoints with a shared URL builder
- update the native deep link to wrap the mobile share URL while keeping the desktop web share URL for browsers

## Testing
- npm run lint *(fails: existing warning in src/components/Popup.jsx about missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d0811968a883259cafe4560c1975d8