### PR TITLE
Update Facebook share deep link to use desktop URL

### DIFF
--- a/src/components/ShareButtons.jsx
+++ b/src/components/ShareButtons.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 const DESKTOP_SHARE_ENDPOINT = "https://www.facebook.com/sharer/sharer.php";
-const MOBILE_SHARE_ENDPOINT = "https://m.facebook.com/sharer.php";
 
 function isMobileDevice() {
   if (typeof navigator === "undefined") {
@@ -35,14 +34,11 @@ function buildFbShareUrl({ shareUrl, quote }, baseUrl) {
 }
 
 function facebookShareTargets(params) {
-  const shareUrls = {
-    web: buildFbShareUrl(params, DESKTOP_SHARE_ENDPOINT),
-    mobile: buildFbShareUrl(params, MOBILE_SHARE_ENDPOINT),
-  };
+  const webShareUrl = buildFbShareUrl(params, DESKTOP_SHARE_ENDPOINT);
 
   return {
-    webShareUrl: shareUrls.web,
-    deepLinkUrl: `fb://facewebmodal/f?href=${encodeURIComponent(shareUrls.mobile)}`,
+    webShareUrl,
+    deepLinkUrl: `fb://facewebmodal/f?href=${encodeURIComponent(webShareUrl)}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- update the Facebook share deep link to encode the desktop sharer endpoint so the quote and link populate consistently
- remove the unused mobile-only sharer endpoint constant

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d148fdabd48325b40126d3d9cd88f2